### PR TITLE
Support sharing PFX file

### DIFF
--- a/src/lib/modules/export.js
+++ b/src/lib/modules/export.js
@@ -1,6 +1,22 @@
 import FileSaver from 'file-saver';
 
-export default function saveAs(params = {}) {
+export function saveAs(params = {}) {
+  const { file, filename, data, type } = {
+    // defaults
+    type: 'text/plain',
+    // overrides
+    ...params
+  };
+
+  if (file) {
+    FileSaver.saveAs(file);
+  } else {
+    const blob = new Blob([data], { type });
+    FileSaver.saveAs(blob, filename);
+  }
+}
+
+export function createFile(params = {}) {
   const { filename, data, type } = {
     // defaults
     type: 'text/plain',
@@ -9,5 +25,5 @@ export default function saveAs(params = {}) {
   };
 
   const blob = new Blob([data], { type });
-  FileSaver.saveAs(blob, filename);
+  return new File([blob], filename, { type });
 }

--- a/src/routes/main/(app)/mail-relay/settings/ProfileKey.svelte
+++ b/src/routes/main/(app)/mail-relay/settings/ProfileKey.svelte
@@ -6,7 +6,7 @@
   import CloseIcon from '$lib/components/materialIcons/CloseIcon.svelte';
   import DownloadIcon from '$lib/components/materialIcons/DownloadIcon.svelte';
   import DownloadingIcon from '$lib/components/materialIcons/DownloadingIcon.svelte';
-  import saveAs from '$lib/modules/export';
+  import { saveAs } from '$lib/modules/export';
   import { showSnackbar } from '$lib/stores/snackbar';
   import { minuteTimer } from '$lib/stores/timers';
   import { X509Certificate } from '@privacyportal/client-certs';

--- a/src/routes/main/(app)/support/+page.svelte
+++ b/src/routes/main/(app)/support/+page.svelte
@@ -13,7 +13,7 @@
   import MailIcon from '$lib/components/materialIcons/MailIcon.svelte';
   import { LANDING_CLIENT_URL } from '$lib/modules/constants';
   import { displayError } from '$lib/modules/errors';
-  import saveAs from '$lib/modules/export';
+  import { saveAs } from '$lib/modules/export';
   import { submitSupportRequest } from '$lib/modules/requests';
   import { gotoExt } from '$lib/modules/routingUtils';
   import { showSnackbar } from '$lib/stores/snackbar';


### PR DESCRIPTION
- Sharing .pfx files gives more control to iOS users over the downloaded file. A normal download on iOS is treated as a profile install and does not allow storage on the filesystem.

- Sharing is also useful for emailing the certificate in case the user's client only supports install by email.