### PR TITLE
Local dev domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "author": "Privacy Portal",
   "license": "MIT",
   "scripts": {

--- a/src/routes/main/(app)/settings/applications/[id]/+page.svelte
+++ b/src/routes/main/(app)/settings/applications/[id]/+page.svelte
@@ -237,7 +237,7 @@
                   type="text"
                   name="url"
                   placeholder="https://<app.url>"
-                  pattern="^http(s:\/\/.+|:\/\/localhost:[0-9]+)$"
+                  pattern="^http(s:\/\/.+|:\/\/(.+\.local|localhost:[0-9]+))$"
                   autocomplete="off"
                   bind:value={_url}
                   disabled={loading}
@@ -254,7 +254,7 @@
                     type="text"
                     name={`callback_url_${index}`}
                     placeholder="https://<app.url>"
-                    pattern="^http(s:\/\/.+|:\/\/localhost:[0-9]+\/.+)$"
+                    pattern="^http(s:\/\/.+|:\/\/(.+\.local|localhost:[0-9]+)(\/.*)?)$"
                     autocomplete="off"
                     on:input={(e) => handleCallbackUrlInput(e, index)}
                     value={callback_url}


### PR DESCRIPTION
This PR allows developers to configure simple `.local` domains when setting up **Sign In With Privacy Portal** for testing.

For example, they can use a `redirect_url` such as `http://my-awesome-app.local/callback`